### PR TITLE
fix: `settings.gradle` 에러 수정

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'kdt_y_be_toy_project2'
+rootProject.name = 'KDT_Y_BE_Toy_Project2'


### PR DESCRIPTION
# 의도
* gradle build 시에 다음 에러가 발생했습니다.

```
java.lang.IllegalStateException: Module entity with name: KDT_Y_BE_Toy_Project2.main should be available
```

* 위 에러는 프로젝트 폴더의 이름과 프로젝트명이 일치않아서 나타나는 에러였습니다.
* 에러를 고치기 위해 `settings.gradle` 의 `rootProject.name` 변수의 값을 깃허브 저장소 이름(KDT_Y_BE_Toy_Project2)과 일치시켜주었습니다.

# 작업사항
- [x] `rootProject.name` 변수의 값을 변경한다.

close #2 