### PR TITLE
[feat] docker-compose.yml 등록을 한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+# Docker Compose
+
+version: '3'
+
+services:
+  mysql:
+    container_name: toy2-mysql
+    image: mysql:8.0
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_USERNAME: ${LOCAL_MYSQL_USERNAME}
+      MYSQL_ROOT_PASSWORD: ${LOCAL_MYSQL_PASSWORD}
+      MYSQL_DATABASE: fc_sns
+      TZ: Asia/Seoul
+    volumes:
+      - ${LOCAL_MYSQL_VOLUME_PATH}:/var/lib/mysql
+    ports:
+      - ${LOCAL_MYSQL_PORT}:3306


### PR DESCRIPTION
Motivation:
- mysql과 같은 프로그램을 팀 내 개발자들이 환경설정 등을 고려하지 않게 만들기 위해 docker compose 도입을 실시했습니다.
- 비밀번호와 같은 민감 정보는 외부 설정파일 `.env` 파일을 사용해 입력을 해주시면 됩니다.

Modification:
- mysql docker compose yml 파일 등록