### PR TITLE
fix: settings.gradle 에러 수정

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/domain/model/TimeScheduleInfo.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/model/TimeScheduleInfo.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-class TimeScheduleInfo {
+public class TimeScheduleInfo {
 
     private LocalDateTime startDateTime;
     private LocalDateTime endDateTime;


### PR DESCRIPTION
# 의도
* `TimeScheduleInfo` 클래스에 `public` 접근자가 없어서 도메인의 엔티티 클래스를 만든 뒤 `TimeScheduleInfo` 클래스에 접근할 때 다음과 같은 에러가 발생했습니다.

```
'com.kdt_y_be_toy_project2.domain.model.TimeScheduleInfo'이(가) 'com.kdt_y_be_toy_project2.domain.model'에서 public이 아닙니다. 외부 패키지에서 액세스할 수 없습니다
```

* 위 에러가 발생함에 따라 클래스에 `public` 접근자를 추가할 예정입니다.

# 작업사항
- [x] `TimeScheduleInfo` 클래스에 `public` 접근자 추가

close #7 