### PR TITLE
[feat] open api 문서 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // 
+//    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kdt_y_be_toy_project2/global/config/OpenApi3Config.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/config/OpenApi3Config.java
@@ -1,0 +1,31 @@
+package com.kdt_y_be_toy_project2.global.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class OpenApi3Config {
+
+    @Bean
+    OpenAPI springShopOpenAPI() {
+        return new OpenAPI()
+            .info(new Info().title("야놀자 토이프로젝트 4조 여행 API 문서")
+                .description("YBE Toy Team4 trip api")
+                .version("v0.0.1"))
+            .externalDocs(new ExternalDocumentation()
+                .description("프로젝트 readme")
+                .url("https://github.com/FastCampusKDTBackend-Toy4/KDT_Y_BE_Toy_Project2"));
+    }
+
+    @Bean
+    GroupedOpenApi tripsApi() {
+        return GroupedOpenApi.builder()
+            .group("여행 API")
+            .pathsToMatch("/v1/trips/**")
+            .build();
+    }
+}


### PR DESCRIPTION
Motivation:
- 문서화를 적용한다면 API를 살펴보는데 더 도움이 된다고 생각하여 적용하게 되었습니다.

Modification:
- `open api` 의존성 추가.
- 간단한 설정 완료 `OpenApi3Config


Note: 
* 간단한 API 문서 demo는 다음과 같습니다.
![image](https://github.com/FastCampusKDTBackend-Toy4/KDT_Y_BE_Toy_Project2/assets/139187207/1b05b81b-dc1b-4797-b1b1-a2c7ec4092c4)

* 경로는 `http://{PROJECT_IP}:{PROJECT_PORT}/swagger-ui/index.html` 로 들어가시면 됩니다.

Close #27 