### PR TITLE
회원 엔티티 생성

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/domain/Member.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/domain/Member.java
@@ -1,0 +1,30 @@
+package com.kdt_y_be_toy_project2.domain.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode(of = "email")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    @Builder
+    private Member(String email, String password, String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.kdt_y_be_toy_project2.domain.member.repository;
+
+import com.kdt_y_be_toy_project2.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, String> {
+
+}


### PR DESCRIPTION
motivation:
- 엔티티 의존관계를 만드는게 우선이기 때문에 회원 도메인을 생성합니다. 비즈니스 로직은 후에 추가될 예정입니다.

modification:
- Member Entity 생성
- Member Repository 생성

Close #80