### PR TITLE
컨트롤러 유닛 테스트 헬퍼 추가

### DIFF
--- a/src/test/java/com/kdt_y_be_toy_project2/global/helper/ControllerUnitTestHelper.java
+++ b/src/test/java/com/kdt_y_be_toy_project2/global/helper/ControllerUnitTestHelper.java
@@ -1,0 +1,20 @@
+package com.kdt_y_be_toy_project2.global.helper;
+
+import com.kdt_y_be_toy_project2.domain.itinerary.controller.ItineraryController;
+import com.kdt_y_be_toy_project2.domain.trip.controller.TripController;
+import com.kdt_y_be_toy_project2.global.security.SecurityConfig;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+/**
+ * This is for Controller layer UnitTest. If you don't want to check authentication and authorization
+ * extend this class in your controller UnitTest class.
+ */
+@WebMvcTest(controllers = {ItineraryController.class, TripController.class},
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+    })
+public class ControllerUnitTestHelper {
+
+}


### PR DESCRIPTION
motivation:
- 컨트롤러 테스트의 경우 인증을 통합 테스트에서만 수행하고 유닛 테스트의 경우에는 인증 테스트를 수행하지 않을 수 있습니다. 위의 문제를 해결하기 위해 SecurityFilter를 잠시 제외하는 HelperClass를 생성했습니다.

modification:
- `ControllerUnitTestHelper` 추가

Close #89