### PR TITLE
[refactor] FormLogin 재등록

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/controller/MemberController.java
@@ -1,12 +1,7 @@
 package com.kdt_y_be_toy_project2.domain.member.controller;
 
-import com.kdt_y_be_toy_project2.domain.member.dto.request.LoginRequest;
-import com.kdt_y_be_toy_project2.domain.member.dto.request.LoginResponse;
 import com.kdt_y_be_toy_project2.domain.member.dto.request.SignUpRequest;
 import com.kdt_y_be_toy_project2.domain.member.service.MemberService;
-import com.kdt_y_be_toy_project2.global.config.CustomHttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,15 +19,5 @@ public class MemberController {
     @PostMapping("/signUp")
     public void join(SignUpRequest request) {
         memberService.signUp(request);
-    }
-
-    @PostMapping("/login")
-    public ResponseEntity<Object> login(LoginRequest loginRequest) {
-        LoginResponse loginResponse = memberService.login(loginRequest);
-
-        return ResponseEntity.status(HttpStatus.OK)
-            .header(CustomHttpHeaders.ACCESS_TOKEN, loginResponse.accessToken())
-            .header(CustomHttpHeaders.REFRESH_TOKEN, loginResponse.refreshToken())
-            .build();
     }
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/service/MemberService.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/service/MemberService.java
@@ -1,13 +1,8 @@
 package com.kdt_y_be_toy_project2.domain.member.service;
 
 import com.kdt_y_be_toy_project2.domain.member.domain.Member;
-import com.kdt_y_be_toy_project2.domain.member.dto.request.LoginRequest;
-import com.kdt_y_be_toy_project2.domain.member.dto.request.LoginResponse;
 import com.kdt_y_be_toy_project2.domain.member.dto.request.SignUpRequest;
 import com.kdt_y_be_toy_project2.domain.member.repository.MemberRepository;
-import com.kdt_y_be_toy_project2.global.jwt.JwtPayload;
-import com.kdt_y_be_toy_project2.global.jwt.JwtProvider;
-import java.util.Date;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -16,13 +11,10 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtProvider jwtProvider;
 
-    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder,
-        JwtProvider jwtProvider) {
+    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
-        this.jwtProvider = jwtProvider;
     }
 
     public void signUp(SignUpRequest request) {
@@ -31,21 +23,5 @@ public class MemberService {
             .password(passwordEncoder.encode(request.password()))
             .name(request.name())
             .build());
-    }
-
-    public LoginResponse login(LoginRequest loginRequest) {
-        Member member = memberRepository.findById(loginRequest.username())
-            .orElseThrow(() -> new IllegalArgumentException("member not found"));
-
-        if (!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
-            throw new IllegalArgumentException("Not match password");
-        }
-
-        String accessToken = jwtProvider.createAccessToken(
-            new JwtPayload(loginRequest.username(), new Date()));
-        String refreshToken = jwtProvider.createRefreshToken(
-            new JwtPayload(loginRequest.username(), new Date()));
-
-        return new LoginResponse(loginRequest.username(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/SecurityConfig.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/SecurityConfig.java
@@ -1,10 +1,17 @@
 package com.kdt_y_be_toy_project2.global.security;
 
+import com.kdt_y_be_toy_project2.global.jwt.JwtProvider;
+import com.kdt_y_be_toy_project2.global.security.formlogin.CustomFormLoginFilter;
+import com.kdt_y_be_toy_project2.global.security.formlogin.CustomFormLoginProvider;
+import com.kdt_y_be_toy_project2.global.security.jwt.JwtAuthenticationFilter;
+import com.kdt_y_be_toy_project2.global.security.jwt.JwtAuthenticationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -13,11 +20,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @EnableWebSecurity(debug = true)
 public class SecurityConfig {
 
-    private final AuthenticationConfiguration authConfiguration;
+    private final UserDetailsService userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
-
-    public SecurityConfig(AuthenticationConfiguration authConfiguration) {
-        this.authConfiguration = authConfiguration;
+    public SecurityConfig(
+        UserDetailsService userDetailsService, AuthenticationConfiguration authenticationConfiguration,
+        JwtAuthenticationProvider jwtAuthenticationProvider) {
+        this.userDetailsService = userDetailsService;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtAuthenticationProvider = jwtAuthenticationProvider;
     }
 
     @Bean
@@ -26,7 +38,25 @@ public class SecurityConfig {
     }
 
     @Bean
-    AuthenticationManager authenticationManager() throws Exception {
-        return authConfiguration.getAuthenticationManager();
+    CustomFormLoginProvider customFormLoginProvider() {
+        return new CustomFormLoginProvider(passwordEncoder(), userDetailsService);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        ProviderManager authenticationManager = (ProviderManager) authenticationConfiguration.getAuthenticationManager();
+        authenticationManager.getProviders().add(customFormLoginProvider());
+        authenticationManager.getProviders().add(jwtAuthenticationProvider);
+        return authenticationManager;
+    }
+
+    @Bean
+    CustomFormLoginFilter customFormLoginFilter(JwtProvider jwtProvider) throws Exception {
+        return new CustomFormLoginFilter(authenticationManager(), jwtProvider);
+    }
+
+    @Bean
+    JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        return new JwtAuthenticationFilter(authenticationManager());
     }
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/SecurityFilterConfig.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/SecurityFilterConfig.java
@@ -1,5 +1,6 @@
 package com.kdt_y_be_toy_project2.global.security;
 
+import com.kdt_y_be_toy_project2.global.security.formlogin.CustomFormLoginFilter;
 import com.kdt_y_be_toy_project2.global.security.jwt.JwtAuthenticationFilter;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -14,28 +15,31 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 public class SecurityFilterConfig {
 
+    private final CustomFormLoginFilter customFormLoginFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-
     public SecurityFilterConfig(
+        CustomFormLoginFilter customFormLoginFilter,
         JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.customFormLoginFilter = customFormLoginFilter;
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
     SecurityFilterChain http(HttpSecurity http) throws Exception {
         http
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(sessionConfig ->
                 sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.authorizeHttpRequests(request ->
-            request.requestMatchers("/v1/members/signUp", "/v1/members/login").permitAll()
+            request.requestMatchers("/v1/members/signUp", "/login").permitAll()
                 .anyRequest().authenticated());
 
-        http.formLogin(AbstractHttpConfigurer::disable);
-
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterAfter(customFormLoginFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/AccountContext.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/AccountContext.java
@@ -1,0 +1,41 @@
+package com.kdt_y_be_toy_project2.global.security.formlogin;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class AccountContext implements UserDetails {
+
+    private final String username;
+    private final String password;
+    private final Collection<GrantedAuthority> authorities;
+
+    public AccountContext(String username, String password,
+        Collection<GrantedAuthority> authorities) {
+        this.username = username;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginFilter.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginFilter.java
@@ -1,0 +1,46 @@
+package com.kdt_y_be_toy_project2.global.security.formlogin;
+
+import com.kdt_y_be_toy_project2.global.config.CustomHttpHeaders;
+import com.kdt_y_be_toy_project2.global.jwt.JwtPayload;
+import com.kdt_y_be_toy_project2.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Date;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+public class CustomFormLoginFilter extends AbstractAuthenticationProcessingFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public CustomFormLoginFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
+        super("/v1/login");
+        setAuthenticationManager(authenticationManager);
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+        HttpServletResponse response)
+        throws AuthenticationException {
+
+        String username = request.getParameter("username");
+        String password = request.getParameter("password");
+
+        return getAuthenticationManager().authenticate(
+            CustomLoginToken.unAuthenticate(username, password));
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+        HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        String email = (String) authResult.getPrincipal();
+
+        response.setHeader(
+            CustomHttpHeaders.ACCESS_TOKEN, jwtProvider.createAccessToken(new JwtPayload(email, new Date())));
+        response.setHeader(CustomHttpHeaders.REFRESH_TOKEN, jwtProvider.createRefreshToken(new JwtPayload(email, new Date())));
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginProvider.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginProvider.java
@@ -1,0 +1,41 @@
+package com.kdt_y_be_toy_project2.global.security.formlogin;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class CustomFormLoginProvider implements AuthenticationProvider {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserDetailsService userDetailsService;
+
+
+    public CustomFormLoginProvider(PasswordEncoder passwordEncoder, UserDetailsService userDetailsService) {
+        this.passwordEncoder = passwordEncoder;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+        String username = (String) authentication.getPrincipal();
+        String password = (String) authentication.getCredentials();
+
+        AccountContext accountContext = (AccountContext) userDetailsService
+            .loadUserByUsername(username);
+
+        if (!passwordEncoder.matches(password, accountContext.getPassword())) {
+            throw new BadCredentialsException("Login Fail");
+        }
+
+        return CustomLoginToken.authenticate(username, accountContext.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return CustomLoginToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomLoginToken.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomLoginToken.java
@@ -1,0 +1,57 @@
+package com.kdt_y_be_toy_project2.global.security.formlogin;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class CustomLoginToken extends AbstractAuthenticationToken {
+
+    private final AccountContext accountContext;
+
+    private CustomLoginToken(AccountContext accountContext,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.accountContext = accountContext;
+    }
+
+    public static CustomLoginToken unAuthenticate(String username, String password) {
+        return new CustomLoginToken(new AccountContext(username, password, Collections.emptySet()), Collections.emptySet());
+    }
+
+    public static CustomLoginToken authenticate(String username,
+        Collection<GrantedAuthority> authorities) {
+        return new CustomLoginToken(new AccountContext(username, null, authorities), authorities);
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return accountContext.getUsername();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return accountContext.getPassword();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        if (!super.equals(object)) {
+            return false;
+        }
+        CustomLoginToken that = (CustomLoginToken) object;
+        return Objects.equals(accountContext, that.accountContext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), accountContext);
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomUserDetailsService.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.kdt_y_be_toy_project2.global.security.formlogin;
+
+import com.kdt_y_be_toy_project2.domain.member.domain.Member;
+import com.kdt_y_be_toy_project2.domain.member.repository.MemberRepository;
+import java.util.Set;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    public CustomUserDetailsService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(username)
+            .orElseThrow(() -> new IllegalArgumentException("member not found"));
+
+        return new AccountContext(member.getEmail(), member.getPassword(),
+            Set.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationFilter.java
@@ -6,17 +6,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final AuthenticationManager authenticationManager;
 
-    public JwtAuthenticationFilter(JwtAuthenticationProvider jwtAuthenticationProvider) {
-        this.jwtAuthenticationProvider = jwtAuthenticationProvider;
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
     }
 
     @Override
@@ -31,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String refreshToken = request.getHeader(CustomHttpHeaders.REFRESH_TOKEN);
 
         SecurityContextHolder.getContext()
-            .setAuthentication(jwtAuthenticationProvider.authenticate(
+            .setAuthentication(authenticationManager.authenticate(
                 JwtAuthenticationToken.unAuthorizeToken(accessToken, refreshToken)));
 
         chain.doFilter(request, response);


### PR DESCRIPTION
motivation:
- Provider을 추가하면서 ProviderManager에 추가가 되지 않는 현상을 발견하였고 이를 해결하지 못해 임시적으로 RestAPI를 제공함으로써 우회했습니다. 하지만위 문제를 해결했기때문에 다시 SecurityFilterChain을 사용합니다.

modification:
- Rest API Login 방식을 Security로 재등록