### PR TITLE
[feat] SecurityContextHolder 데이터를 추출할 ArgumentResolver 추가

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/global/config/WebMvcConfig.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.kdt_y_be_toy_project2.global.config;
+
+import com.kdt_y_be_toy_project2.global.resolver.LoginInfoArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginInfoArgumentResolver loginInfoArgumentResolver;
+
+    public WebMvcConfig(LoginInfoArgumentResolver loginInfoArgumentResolver) {
+        this.loginInfoArgumentResolver = loginInfoArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginInfoArgumentResolver);
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/resolver/LoginInfo.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/resolver/LoginInfo.java
@@ -1,0 +1,7 @@
+package com.kdt_y_be_toy_project2.global.resolver;
+
+public record LoginInfo(
+    String username
+) {
+
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/resolver/LoginInfoArgumentResolver.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/resolver/LoginInfoArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.kdt_y_be_toy_project2.global.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = (String) authentication.getPrincipal();
+        return new LoginInfo(username);
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(SecurityContext.class) != null
+            && parameter.getParameterType().isAssignableFrom(LoginInfo.class);
+    }
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/global/resolver/SecurityContext.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/resolver/SecurityContext.java
@@ -1,0 +1,12 @@
+package com.kdt_y_be_toy_project2.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SecurityContext {
+
+}


### PR DESCRIPTION
motivation:
- 로그인을 성공한다면, SecurityContext 에서 정보를 가져올 수 있습니다. 하지만 Controller 에서 굳이 Spring Security 와 같은 Low Level Spec를 사용하기에는 부적절해보입니다. 이를 해결하기 위해 `ArgumentResolver`을 사용해 결합도를 약하게 만드려 합니다.

modification:
- `LoginInfoArgumentResolver` 추가
- `LoginInfo` 추가

Close #104