### PR TITLE
[refactor] JwtFilter 의존성 변경

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginFilter.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/formlogin/CustomFormLoginFilter.java
@@ -2,7 +2,8 @@ package com.kdt_y_be_toy_project2.global.security.formlogin;
 
 import com.kdt_y_be_toy_project2.global.config.CustomHttpHeaders;
 import com.kdt_y_be_toy_project2.global.jwt.JwtPayload;
-import com.kdt_y_be_toy_project2.global.jwt.JwtProvider;
+import com.kdt_y_be_toy_project2.global.jwt.service.JwtService;
+import com.kdt_y_be_toy_project2.global.jwt.service.TokenPair;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,12 +15,12 @@ import org.springframework.security.web.authentication.AbstractAuthenticationPro
 
 public class CustomFormLoginFilter extends AbstractAuthenticationProcessingFilter {
 
-    private final JwtProvider jwtProvider;
+    private final JwtService jwtService;
 
-    public CustomFormLoginFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
+    public CustomFormLoginFilter(AuthenticationManager authenticationManager, JwtService jwtService) {
         super("/v1/login");
         setAuthenticationManager(authenticationManager);
-        this.jwtProvider = jwtProvider;
+        this.jwtService = jwtService;
     }
 
     @Override
@@ -38,9 +39,9 @@ public class CustomFormLoginFilter extends AbstractAuthenticationProcessingFilte
     protected void successfulAuthentication(HttpServletRequest request,
         HttpServletResponse response, FilterChain chain, Authentication authResult) {
         String email = (String) authResult.getPrincipal();
-
+        TokenPair tokenPair = jwtService.createTokenPair(new JwtPayload(email, new Date()));
         response.setHeader(
-            CustomHttpHeaders.ACCESS_TOKEN, jwtProvider.createAccessToken(new JwtPayload(email, new Date())));
-        response.setHeader(CustomHttpHeaders.REFRESH_TOKEN, jwtProvider.createRefreshToken(new JwtPayload(email, new Date())));
+            CustomHttpHeaders.ACCESS_TOKEN, tokenPair.accessToken());
+        response.setHeader(CustomHttpHeaders.REFRESH_TOKEN, tokenPair.refreshToken());
     }
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationFilter.java
@@ -27,17 +27,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String accessToken = request.getHeader(CustomHttpHeaders.ACCESS_TOKEN);
-        String refreshToken = request.getHeader(CustomHttpHeaders.REFRESH_TOKEN);
 
         SecurityContextHolder.getContext()
             .setAuthentication(authenticationManager.authenticate(
-                JwtAuthenticationToken.unAuthorizeToken(accessToken, refreshToken)));
+                JwtAuthenticationToken.unAuthorize(accessToken)));
 
         chain.doFilter(request, response);
     }
 
     private boolean hasJwtToken(HttpServletRequest request) {
-        return request.getHeader(CustomHttpHeaders.ACCESS_TOKEN) != null &&
-            request.getHeader(CustomHttpHeaders.REFRESH_TOKEN) != null;
+        return request.getHeader(CustomHttpHeaders.ACCESS_TOKEN) != null;
     }
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationProvider.java
@@ -22,7 +22,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         String accessToken = (String) authentication.getCredentials();
         JwtPayload jwtPayload = jwtService.verifyToken(accessToken);
 
-        return JwtAuthenticationToken.authorizeToken(jwtPayload.email());
+        return JwtAuthenticationToken.authorize(jwtPayload.email());
     }
 
     @Override

--- a/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/global/security/jwt/JwtAuthenticationToken.java
@@ -1,36 +1,34 @@
 package com.kdt_y_be_toy_project2.global.security.jwt;
 
+import java.util.Objects;
 import java.util.Set;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
-    private String principal;
-    private JwtPair credentials;
+    private final String principal;
+    private String credentials;
     private final boolean isAuthenticated;
 
-    private JwtAuthenticationToken(String accessToken, String refreshToken, boolean isAuthenticated) {
+    private JwtAuthenticationToken(String principal, String credentials, boolean isAuthenticated) {
         super(Set.of(new SimpleGrantedAuthority("ROLE_USER")));
-        this.credentials = new JwtPair(accessToken, refreshToken);
+        this.principal = principal;
+        this.credentials = credentials;
         this.isAuthenticated = isAuthenticated;
     }
 
-    private JwtAuthenticationToken(String email, boolean isAuthenticated) {
+    private JwtAuthenticationToken(String principal, boolean isAuthenticated) {
         super(Set.of(new SimpleGrantedAuthority("ROLE_USER")));
-        this.principal = email;
+        this.principal = principal;
         this.isAuthenticated = isAuthenticated;
     }
 
-    public static JwtAuthenticationToken emptyToken() {
-        return new JwtAuthenticationToken(null, null, false);
+    public static JwtAuthenticationToken unAuthorize(String accessToken) {
+        return new JwtAuthenticationToken(null, accessToken, false);
     }
 
-    public static JwtAuthenticationToken unAuthorizeToken(String accessToken, String refreshToken) {
-        return new JwtAuthenticationToken(accessToken, refreshToken, false);
-    }
-
-    public static JwtAuthenticationToken authorizeToken(String email) {
+    public static JwtAuthenticationToken authorize(String email) {
         return new JwtAuthenticationToken(email, true);
     }
 
@@ -40,12 +38,33 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     @Override
-    public JwtPair getCredentials() {
+    public String getCredentials() {
         return credentials;
     }
 
     @Override
     public boolean isAuthenticated() {
         return isAuthenticated;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        if (!super.equals(object)) {
+            return false;
+        }
+        JwtAuthenticationToken that = (JwtAuthenticationToken) object;
+        return isAuthenticated == that.isAuthenticated && Objects.equals(principal,
+            that.principal) && Objects.equals(credentials, that.credentials);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), principal, credentials, isAuthenticated);
     }
 }


### PR DESCRIPTION
motivation:
- `JwtProvider` 대신 `JwtService`를 사용하기 때문에 의존성 변경을 합니다.
- filter에서 매번 refreshToken을 받지 않기 때문에 인증로직에서도 refreshToken을 제외합니다.

modification:
- 인증 로직에서 refreshToken 제외
- jwtProvider 의존성 변경