### PR TITLE
[feat] 댓글 등록, 조회 기능 추가

### DIFF
--- a/src/main/java/com/kdt_y_be_toy_project2/KdtYBeToyProject2Application.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/KdtYBeToyProject2Application.java
@@ -2,7 +2,9 @@ package com.kdt_y_be_toy_project2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KdtYBeToyProject2Application {
 

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/domain/Member.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/domain/Member.java
@@ -1,7 +1,14 @@
 package com.kdt_y_be_toy_project2.domain.member.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.kdt_y_be_toy_project2.domain.trip.domain.Comment;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -20,6 +27,9 @@ public class Member {
     private String password;
 
     private String name;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Comment> comments = new ArrayList<>();
 
     @Builder
     private Member(String email, String password, String name) {

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/member/repository/MemberRepository.java
@@ -1,8 +1,13 @@
 package com.kdt_y_be_toy_project2.domain.member.repository;
 
+import java.util.Optional;
+
 import com.kdt_y_be_toy_project2.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
 
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/controller/TripController.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/controller/TripController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt_y_be_toy_project2.domain.trip.dto.FindTripResponse;
+import com.kdt_y_be_toy_project2.domain.trip.dto.TripCommentRequest;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripRequest;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripResponse;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripSearchRequest;
@@ -60,7 +62,7 @@ public class TripController {
 	})
 	@Operation(summary = "여행 조회", description = "하나의 여행을 조회하는 메소드입니다.")
 	@GetMapping("/{trip_id}")
-	public ResponseEntity<TripResponse> getTripById(
+	public ResponseEntity<FindTripResponse> getTripById(
 		@Parameter(description = "여행 ID", required = true, example = "1")
 		@PathVariable(name = "trip_id") final Long tripId
 	) {
@@ -129,6 +131,14 @@ public class TripController {
 		@SecurityContext LoginInfo loginInfo
 	) {
 		tripService.addLikeTrip(tripId, loginInfo.username());
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PostMapping("/{trip_id}/comments")
+	public ResponseEntity<Void> addLikeTrip(@Valid @RequestBody TripCommentRequest tripCommentRequest,
+		@PathVariable(name = "trip_id") final Long tripId, @SecurityContext LoginInfo loginInfo) {
+		tripService.createComment(tripCommentRequest, tripId, loginInfo.username());
+
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/domain/Comment.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/domain/Comment.java
@@ -1,0 +1,60 @@
+package com.kdt_y_be_toy_project2.domain.trip.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.kdt_y_be_toy_project2.domain.member.domain.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "trip_id")
+	private Trip trip;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Lob
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	@CreatedDate
+	private LocalDateTime createdDateTime;
+
+	public void setTrip(Trip trip) {
+		this.trip = trip;
+	}
+
+	public void setMember(Member member) {
+		this.member = member;
+	}
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/domain/Trip.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/domain/Trip.java
@@ -61,6 +61,9 @@ public class Trip {
 	})
 	private DateScheduleInfo tripSchedule;
 
+	@OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+	List<Comment> comments = new ArrayList<>();
+
 	@Builder
 	private Trip(Long id, Member member, String name, TripType tripType, DateScheduleInfo tripSchedule) {
 		this.id = id;

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/CommentResponse.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/CommentResponse.java
@@ -1,0 +1,7 @@
+package com.kdt_y_be_toy_project2.domain.trip.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record CommentResponse(List<Map<String, Object>> comments) {
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/FindTripResponse.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/FindTripResponse.java
@@ -1,6 +1,7 @@
 package com.kdt_y_be_toy_project2.domain.trip.dto;
 
 import java.util.List;
+import java.util.Map;
 
 import com.kdt_y_be_toy_project2.domain.itinerary.dto.ItineraryResponse;
 import com.kdt_y_be_toy_project2.domain.trip.domain.Trip;
@@ -10,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record TripResponse(
+public record FindTripResponse(
 	@Schema(description = "여행 ID")
 	Long tripId,
 
@@ -26,21 +27,23 @@ public record TripResponse(
 	@Schema(description = "여행 국내외여부")
 	String tripType,
 
-	@Schema(description = "여행 좋아요 개수")
-	Long likesCount,
-
 	@Schema(description = "여행에 포함된 여정 리스트")
-	List<ItineraryResponse> itineraries
+	List<ItineraryResponse> itineraries,
+
+	@Schema(description = "여행 댓글")
+	CommentResponse commentResponse
 ) {
-	public static TripResponse from(Trip trip) {
-		return TripResponse.builder()
+	public static FindTripResponse from(Trip trip, List<Map<String, Object>> lists) {
+		CommentResponse commentResponse = new CommentResponse(lists);
+
+		return FindTripResponse.builder()
 			.tripId(trip.getId())
 			.tripName(trip.getName())
 			.startDate(DateTimeUtil.toString(trip.getTripSchedule().getStartDate()))
 			.endDate(DateTimeUtil.toString(trip.getTripSchedule().getEndDate()))
 			.tripType(trip.getTripType().getValue())
-			.likesCount(trip.getLikesCount())
 			.itineraries(trip.getItineraries().stream().map(ItineraryResponse::from).toList())
+			.commentResponse(commentResponse)
 			.build();
 	}
 }

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/TripCommentRequest.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/dto/TripCommentRequest.java
@@ -1,0 +1,6 @@
+package com.kdt_y_be_toy_project2.domain.trip.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TripCommentRequest(@NotBlank(message = "댓글을 입력해주세요.") String content) {
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/repository/CommentRepository.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.kdt_y_be_toy_project2.domain.trip.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.kdt_y_be_toy_project2.domain.trip.domain.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/kdt_y_be_toy_project2/domain/trip/service/TripService.java
+++ b/src/main/java/com/kdt_y_be_toy_project2/domain/trip/service/TripService.java
@@ -1,7 +1,9 @@
 package com.kdt_y_be_toy_project2.domain.trip.service;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -11,15 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kdt_y_be_toy_project2.domain.member.domain.Member;
 import com.kdt_y_be_toy_project2.domain.member.repository.MemberRepository;
 import com.kdt_y_be_toy_project2.domain.model.exception.InvalidDateRangeException;
+import com.kdt_y_be_toy_project2.domain.trip.domain.Comment;
 import com.kdt_y_be_toy_project2.domain.trip.domain.Likes;
 import com.kdt_y_be_toy_project2.domain.trip.domain.Trip;
 import com.kdt_y_be_toy_project2.domain.trip.domain.id.LikesID;
+import com.kdt_y_be_toy_project2.domain.trip.dto.FindTripResponse;
+import com.kdt_y_be_toy_project2.domain.trip.dto.TripCommentRequest;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripRequest;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripResponse;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripSearchRequest;
 import com.kdt_y_be_toy_project2.domain.trip.exception.TripAlreadyLikesException;
 import com.kdt_y_be_toy_project2.domain.trip.exception.TripNotFoundException;
 import com.kdt_y_be_toy_project2.domain.trip.exception.TripSearchIllegalArgumentException;
+import com.kdt_y_be_toy_project2.domain.trip.repository.CommentRepository;
 import com.kdt_y_be_toy_project2.domain.trip.repository.LikesRepository;
 import com.kdt_y_be_toy_project2.domain.trip.repository.TripRepository;
 import com.kdt_y_be_toy_project2.global.resolver.LoginInfo;
@@ -34,6 +40,7 @@ public class TripService {
 	private final TripRepository tripRepository;
 	private final LikesRepository likesRepository;
 	private final MemberRepository memberRepository;
+	private final CommentRepository commentRepository;
 
 	@Transactional(readOnly = true)
 	public List<TripResponse> getAllTrips() {
@@ -42,16 +49,23 @@ public class TripService {
 		if (trips.isEmpty()) {
 			throw new TripNotFoundException();
 		}
-		return trips
-			.stream().map(TripResponse::from)
-			.toList();
+		return trips.stream().map(TripResponse::from).toList();
 	}
 
 	@Transactional(readOnly = true)
-	public TripResponse getTripById(final Long tripId) {
-		return tripRepository.findById(tripId)
-			.map(TripResponse::from)
-			.orElseThrow(TripNotFoundException::new);
+	public FindTripResponse getTripById(final Long tripId) {
+		Trip trip = tripRepository.findById(tripId).orElseThrow(TripNotFoundException::new);
+		List<Map<String, Object>> commentInfos = trip.getComments().stream()
+			.map(comment -> {
+				Map<String, Object> commentInfo = new HashMap<>();
+				commentInfo.put("content", comment.getContent());
+				commentInfo.put("email", comment.getMember().getEmail());
+				commentInfo.put("createDateTime", comment.getCreatedDateTime());
+
+				return commentInfo;
+			}).toList();
+
+		return FindTripResponse.from(trip, commentInfos);
 	}
 
 	public TripResponse createTrip(final TripRequest request, LoginInfo loginInfo) {
@@ -131,5 +145,16 @@ public class TripService {
 			.trip(trip)
 			.build();
 		likesRepository.save(newLikes);
+	}
+
+	public void createComment(TripCommentRequest dto, Long tripId, String email) {
+		Trip trip = tripRepository.findById(tripId).orElseThrow(TripNotFoundException::new);
+		Member member = memberRepository.findByEmail(email).orElseThrow();
+		Comment comment = Comment.builder()
+			.trip(trip)
+			.member(member)
+			.content(dto.content())
+			.build();
+		commentRepository.save(comment);
 	}
 }

--- a/src/test/java/com/kdt_y_be_toy_project2/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/com/kdt_y_be_toy_project2/domain/trip/service/TripServiceTest.java
@@ -21,6 +21,7 @@ import com.kdt_y_be_toy_project2.domain.member.repository.MemberRepository;
 import com.kdt_y_be_toy_project2.domain.model.DateScheduleInfo;
 import com.kdt_y_be_toy_project2.domain.trip.domain.Trip;
 import com.kdt_y_be_toy_project2.domain.trip.domain.type.TripType;
+import com.kdt_y_be_toy_project2.domain.trip.dto.FindTripResponse;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripRequest;
 import com.kdt_y_be_toy_project2.domain.trip.dto.TripResponse;
 import com.kdt_y_be_toy_project2.domain.trip.exception.TripNotFoundException;
@@ -109,10 +110,10 @@ class TripServiceTest {
 		given(tripRepository.findById(anyLong())).willReturn(Optional.ofNullable(trip2));
 
 		// when
-		TripResponse tripResponse = tripService.getTripById(anyLong());
+		FindTripResponse findTripResponse = tripService.getTripById(anyLong());
 
 		// then
-		assertThat(tripResponse.tripName()).isEqualTo("Test Trip2");
+		assertThat(findTripResponse.tripName()).isEqualTo("Test Trip2");
 	}
 
 	@DisplayName("여행 ID 조회 실패")

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,16 +3,8 @@ spring:
     import: optional:file:.env[.properties]
   application:
     name: KDT-5
-  jpa:
-    show-sql: true
-    hibernate:
-      ddl-auto: create
-  datasource:
-    url: jdbc:h2:mem:test
-    username: sa
-    driver-class-name: org.h2.Driver
-
-
+  profiles:
+    include: dev
 
 service:
   jwt:
@@ -23,3 +15,19 @@ service:
 kakao:
   rest:
     api-key: ${KAKAO_API_KEY}
+  datasource:
+    url: jdbc:mysql://localhost:${LOCAL_MYSQL_PORT}/fc_sns?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${LOCAL_MYSQL_USERNAME}
+    password: ${LOCAL_MYSQL_PASSWORD}
+
+  jpa:
+    properties:
+      format_sql: true
+      dialect: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: validate
+
+logging:
+  level:
+    org.springframework.security: debug


### PR DESCRIPTION
motivation:
- 모든 사용자는 본인 포함 다른 사용자의 여행에 대하여 댓글을 중복 등록할 수 있습니다.
- 전체 여행 조회 시에는 댓글이 출력되지 않고, 여행 선택 조회 시 해당 여행의 댓글이 출력됩니다.

modification:
- 댓글 등록 기능 추가
- 여행 선택 조회 시 댓글 리스트 조회 기능 추가